### PR TITLE
docs(cask): clarify sublime-text uses Linux-only tarball with verified SHA256

### DIFF
--- a/Casks/sublime-text.rb
+++ b/Casks/sublime-text.rb
@@ -2,6 +2,9 @@ cask "sublime-text" do
   version "4200"
   sha256 "36f69c551ad18ee46002be4d9c523fe545d93b67fea67beea731e724044b469f"
 
+  # Linux x64 tarball (Priority 1 format - preferred)
+  # Verified: SHA256 calculated from official download
+  # Platform: Linux x86_64 only
   url "https://download.sublimetext.com/sublime_text_build_#{version}_x64.tar.xz"
   name "Sublime Text"
   desc "Sophisticated text editor for code, markup and prose"


### PR DESCRIPTION
## Summary

Adds explicit documentation to the `sublime-text` cask to confirm it uses the Linux-only tarball with verified SHA256 checksum.

## Changes

**Added comments to clarify:**
- Package format: Linux x64 tarball (Priority 1 - preferred format)
- Platform: Linux x86_64 only (not macOS/Windows)
- SHA256 verification: Calculated from official download and verified

## Package Format Verification

**Format Used:** Tarball (Priority 1 - PREFERRED)
```
URL: https://download.sublimetext.com/sublime_text_build_4200_x64.tar.xz
Format: .tar.xz (Linux tarball)
Architecture: x64 (x86_64)
```

**Why this is correct:**
- Tarballs are Priority 1 (most preferred format per repository standards)
- Cross-distribution compatible
- No package manager dependencies
- Simple extraction

## SHA256 Verification

**Calculated SHA256:**
```
36f69c551ad18ee46002be4d9c523fe545d93b67fea67beea731e724044b469f
```

**Verification performed:**
```bash
curl -LO https://download.sublimetext.com/sublime_text_build_4200_x64.tar.xz
sha256sum sublime_text_build_4200_x64.tar.xz
# Result: 36f69c551ad18ee46002be4d9c523fe545d93b67fea67beea731e724044b469f
```

**Upstream checksums:** Not provided by Sublime HQ
- Sublime Text does not publish separate checksum files
- Using calculated SHA256 from official download
- Downloaded from official sublimetext.com domain (HTTPS)

## Linux-Only Verification

- File name contains `_x64` (Linux x86_64 architecture)
- `.tar.xz` format (standard Linux tarball)
- No macOS indicators (no `-darwin-`, `-macos-`, `.dmg`, `.pkg`)
- No Windows indicators (no `.exe`, `.msi`, `-windows-`)

## Note

This cask has always used the Linux tarball since the initial commit (c487b2c). This PR adds documentation to make the Linux-only nature explicit and document the verification process per new repository standards.

## Checklist

- [x] Package format priority followed (tarball - Priority 1)
- [x] SHA256 calculated and verified
- [x] Linux-only confirmed (x64 tarball)
- [x] Correct cask syntax (proper stanza ordering)
- [x] No invalid directives (no depends_on :linux, no test blocks)